### PR TITLE
Update `scala-cli-setup` & fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     # - uses: coursier/cache-action@v6.3
     - uses: VirtusLab/scala-cli-setup@v1.0
     - name: Test
-      run: scala-cli test src --cross
+      run: scala-cli --power test src --cross
 
   # publish:
   #   needs: test
@@ -30,7 +30,7 @@ jobs:
   #   - uses: coursier/cache-action@v6.3
   #   - uses: VirtusLab/scala-cli-setup@v1.0
   #   - name: Publish
-  #     run: scala-cli publish src --cross
+  #     run: scala-cli --power publish src --cross
   #     env:
   #       PUBLISH_USER: ${{ secrets.PUBLISH_USER }}
   #       PUBLISH_PASSWORD: ${{ secrets.PUBLISH_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         fetch-depth: 0
     # - uses: coursier/cache-action@v6.3
-    - uses: VirtusLab/scala-cli-setup@v0.1
+    - uses: VirtusLab/scala-cli-setup@v1.0
     - name: Test
       run: scala-cli test src --cross
 
@@ -28,7 +28,7 @@ jobs:
   #     with:
   #       fetch-depth: 0
   #   - uses: coursier/cache-action@v6.3
-  #   - uses: VirtusLab/scala-cli-setup@v0.1
+  #   - uses: VirtusLab/scala-cli-setup@v1.0
   #   - name: Publish
   #     run: scala-cli publish src --cross
   #     env:
@@ -46,7 +46,7 @@ jobs:
       with:
         fetch-depth: 0
     # - uses: coursier/cache-action@v6.3
-    - uses: VirtusLab/scala-cli-setup@v0.1
+    - uses: VirtusLab/scala-cli-setup@v1.0
     - name: Create and upload archives
       run: scala-cli run Upload.scala
       env:

--- a/Upload.scala
+++ b/Upload.scala
@@ -30,7 +30,7 @@ object Upload {
     }
     if (!dummy)
       io.github.alexarchambault.millnativeimage.upload.Upload.upload(
-        ghOrg = "scala-cli",
+        ghOrg = "VirtusLab",
         ghProj = "lightweight-spark-distrib",
         ghToken = token,
         tag = tag,


### PR DESCRIPTION
I believe the `package` job should run with this (or if it won't it might be broken in the first place)

Tried generating the package as per the readme.

```sh
▶ scala-cli run \
    --workspace . \
    src \
    -- \
      --dest spark-3.0.3-bin-hadoop2.7-lightweight.tgz \
      https://archive.apache.org/dist/spark/spark-3.0.3/spark-3.0.3-bin-hadoop2.7.tgz \
      --spark 3.0.3 \
      --scala 2.12.10 \
      --archive
Compiling project (Scala 2.13.8, JVM)
Warning: 1 deprecation (since 2.13.3); re-run with -deprecation for details
Compiled project (Scala 2.13.8, JVM)
[hint] ./src/Convert.scala:2:16
[hint] "os-lib is outdated, update to 0.9.1"
[hint]      os-lib 0.8.1 -> com.lihaoyi::os-lib:0.9.1
[hint] //> using lib "com.lihaoyi::os-lib:0.8.1"
[hint]                ^^^^^^^^^^^^^^^^^^^^^^^^^
[hint] ./src/Convert.scala:3:16
[hint] "pprint is outdated, update to 0.8.1"
[hint]      pprint 0.7.3 -> com.lihaoyi::pprint:0.8.1
[hint] //> using lib "com.lihaoyi::pprint:0.7.3"
[hint]                ^^^^^^^^^^^^^^^^^^^^^^^^^
[hint] ./src/Convert.scala:4:16
[hint] "coursier is outdated, update to 2.1.7"
[hint]      coursier 2.1.0-M5-24-g678b31710 -> io.get-coursier::coursier:2.1.7
[hint] //> using lib "io.get-coursier::coursier:2.1.0-M5-24-g678b31710"
[hint]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[hint] ./src/Convert.scala:5:16
[hint] "dependency is outdated, update to 0.2.3"
[hint]      dependency 0.2.2 -> io.get-coursier::dependency:0.2.3
[hint] //> using lib "io.get-coursier::dependency:0.2.2"
[hint]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[hint] ./src/Convert.scala:6:16
[hint] "commons-compress is outdated, update to 1.24.0"
[hint]      commons-compress 1.21 -> org.apache.commons:commons-compress:1.24.0
[hint] //> using lib "org.apache.commons:commons-compress:1.21"
[hint]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Fetching Spark JARs via coursier
Got 264 JARs
Error: could not get stax:stax-api:1.0-2 (no file found)
Warning: spark-3.0.3-bin-hadoop2.7/jars/stax-api-1.0-2.jar (stax-api) not found
Warning: spark-3.0.3-bin-hadoop2.7/yarn/spark-3.0.3-yarn-shuffle.jar (spark-3.0.3-yarn-shuffle) not found
Warning: spark-3.0.3-bin-hadoop2.7/examples/jars/spark-examples_2.12-3.0.3.jar (spark-examples_2.12) not found
```

The `tar.gz` seems to generate on my local, despite errors suggesting othjerwise.
```sh
▶ ls  | grep spark
spark-3.0.3-bin-hadoop2.7-lightweight.tgz
```
